### PR TITLE
A fair notice on the copyrights of the whole team.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,11 +3,11 @@ MultiCraft Open Sourse Project
 
 MultiCraft is an open source sandbox game inspired by [Minecraft](https://minecraft.net/).
 
-MultiCraft is based on Minetest which is developed by a [number of contributors](https://github.com/minetest/minetest/graphs/contributors) from all over the globe. Multicraft is developed by a number of contributors too.
+MultiCraft is based on Minetest which is developed by a [number of contributors](https://github.com/minetest/minetest/graphs/contributors) from all over the globe. MultiCraft is developed by a number of contributors too.
 
 It aims to make the game fun while trading off some bits of perfectionism.
 
-Copyright (c) 2014-2015 Maksim Gamarnik [MoNTE48] <MoNTE48@mail.ua> & Multicraft Developement Team.
+Copyright (c) 2014-2015 Maksim Gamarnik [MoNTE48] <MoNTE48@mail.ua> & MultiCraft Developement Team.
 
 In case you downloaded the source code:
 ---------------------------------------


### PR DESCRIPTION
One man can't hold all copyrights.
All contributors to a LGPL project hold that too.
So, at least a note on others should be there.

I also suggest to go by the name of Multicraft Development Team - whomever in - no need to change anything. 
