### PR TITLE
Disable CSM at compile-time

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -53,7 +53,8 @@ LOCAL_CFLAGS := -D_IRR_ANDROID_PLATFORM_ \
 		-DUSE_GETTEXT=1                  \
 		-DUSE_LEVELDB=1                  \
 		$(GPROF_DEF)                     \
-		-pipe
+		-pipe                            \
+		-DDISABLE_CSM
 
 ifndef NDEBUG
 LOCAL_CFLAGS += -g -D_DEBUG -O0 -fno-omit-frame-pointer

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -126,10 +126,12 @@ bool Camera::successfullyCreated(std::string &error_message)
 	} else {
 		error_message.clear();
 	}
-	
+
+#ifndef DISABLE_CSM
 	if (g_settings->getBool("enable_client_modding")) {
 		m_client->getScript()->on_camera_ready(this);
 	}
+#endif
 	return error_message.empty();
 }
 

--- a/src/script/scripting_client.cpp
+++ b/src/script/scripting_client.cpp
@@ -32,6 +32,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_localplayer.h"
 #include "lua_api/l_camera.h"
 
+#ifndef DISABLE_CSM
+
 ClientScripting::ClientScripting(Client *client):
 	ScriptApiBase()
 {
@@ -86,3 +88,5 @@ void ClientScripting::on_camera_ready(Camera *camera)
 {
 	LuaCamera::create(getStack(), camera);
 }
+
+#endif


### PR DESCRIPTION
not tested because gradle didn't work
the compiler should remove all csm code since those functions are never called