### PR TITLE
drawscene.cpp: Change iterator type to remove compilation warning

### DIFF
--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -647,7 +647,7 @@ void draw_load_screen(const std::wstring &text, IrrlichtDevice* device,
 			core::rect<s32>(img_pos.X, img_pos.Y, img_pos.X + imgW, img_pos.Y + imgH),
 			core::rect<s32>(0, 0, img_size.Width, img_size.Height),
 			0, 0, true);
-		for (int i = 0; i < ARRLEN(rects); i++) {
+		for (u32 i = 0; i < ARRLEN(rects); i++) {
 			const s32 clipx = (percent * img_size.Width) / 100;
 			core::rect<s32> r(
 				MYMIN(rects[i].UpperLeftCorner.X, clipx), rects[i].UpperLeftCorner.Y,


### PR DESCRIPTION
Warning was for line 650, comparison between signed and unsigned integers.
Make iterator 'i' a u32.
/////////////

@MoNTE48 
I can compile MultiCraft but cannot run it on desktop for some reason, so this may need testing, however this does fix the warning.
@sfan5 this is your code, seem ok?