### PR TITLE
Various fixes for 'stairs' and 'hud' mods

### DIFF
--- a/games/default/files/hud/builtin.lua
+++ b/games/default/files/hud/builtin.lua
@@ -1,3 +1,4 @@
+HUD_ENABLE_HUNGER = nil -- MC add line **************************************************
 
 HUD_IW_MAX = 8
 HUD_IW_TICK = 0.4

--- a/games/default/files/stairs/depends.txt
+++ b/games/default/files/stairs/depends.txt
@@ -1,1 +1,4 @@
 default
+mobs
+mobs_animal
+wool

--- a/games/default/files/stairs/init.lua
+++ b/games/default/files/stairs/init.lua
@@ -285,7 +285,7 @@ end
 
 --= Mobs Mod
 
-if mobs and mobs.mod and mobs.mod == "redo" then
+if minetest.get_modpath("mobs") and minetest.get_modpath("mobs_animal") then
 
 grp = {crumbly = 3, flammable = 2, not_in_craft_guide = 1}
 
@@ -293,12 +293,6 @@ stairs.register_all("cheeseblock", "mobs:cheeseblock",
 	grp,
 	{"mobs_cheeseblock.png"},
 	"Cheese Block",
-	stairs.dirt)
-
-stairs.register_all("honey_block", "mobs:honey_block",
-	grp,
-	{"mobs_honey_block.png"},
-	"Honey Block",
 	stairs.dirt)
 
 end


### PR DESCRIPTION
Fix undeclared global variables in 'stairs' and 'hud' mods.

Stairs mod:
Add to 'depends.txt' to enable cheeseblock and wool slabs/stairs.
Improve detection of mobs mods.
Remove 'mobs:honey_block' slabs/stairs as the node does not exist.
//////////////

Tested.
Partly fixes #89 but the warnings for dungeon_loot mod are difficult to fix, i will contact the mod author about this.