### PR TITLE
Mono font path setting: Fix path to missing font

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -655,7 +655,7 @@ font_shadow (Font shadow) int 1
 #    Font shadow alpha (opaqueness, between 0 and 255).
 font_shadow_alpha (Font shadow alpha) int 127 0 255
 
-mono_font_path (Monospace font path) path fonts/liberationmono.ttf
+mono_font_path (Monospace font path) path fonts/Cousine-Regular.ttf
 
 mono_font_size (Monospace font size) int 15
 

--- a/multicraft.conf.example
+++ b/multicraft.conf.example
@@ -771,7 +771,7 @@ max_out_chat_queue_size = 20
 # font_shadow_alpha = 127
 
 #    type: path
-# mono_font_path = fonts/liberationmono.ttf
+# mono_font_path = fonts/Cousine-Regular.ttf
 
 #    type: int
 # mono_font_size = 15

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -236,7 +236,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("font_path", porting::getDataPath("fonts" DIR_DELIM "retrovillenc.ttf"));
 	settings->setDefault("font_shadow", "1");
 	settings->setDefault("font_shadow_alpha", "127");
-	settings->setDefault("mono_font_path", porting::getDataPath("fonts" DIR_DELIM "liberationmono.ttf"));
+	settings->setDefault("mono_font_path", porting::getDataPath("fonts" DIR_DELIM "Cousine-Regular.ttf"));
 	settings->setDefault("fallback_font_path", porting::getDataPath("fonts" DIR_DELIM "DroidSansFallback.ttf"));
 
 	settings->setDefault("fallback_font_shadow", "1");


### PR DESCRIPTION
Previous path was to 'liberationmono.ttf' which does not exist, this caused
a crash when trying to test mgv7p.
Change to 'Cousine-Regular.ttf' as in latest Minetest.
/////////////////

Same setting as Minetest https://github.com/minetest/minetest/blob/master/src/defaultsettings.cpp#L264